### PR TITLE
feat(blacklist-tags): Add blacklist filtering with conflict detection & optimize perf/code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,180 @@
-.vscode
-.flatpak
-.flatpak-builder
-flatpak
-build
+# File created using '.gitignore Generator' for Visual Studio Code: https://bit.ly/vscode-gig
+# Created by https://www.toptal.com/developers/gitignore/api/python
+# Edit at https://www.toptal.com/developers/gitignore?templates=python
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/
+
+### Python Patch ###
+# Poetry local configuration file - https://python-poetry.org/docs/configuration/#local-configuration
+poetry.toml
+
+# ruff
+.ruff_cache/
+
+# LSP config files
+pyrightconfig.json
+
+# End of https://www.toptal.com/developers/gitignore/api/python
+
+# Custom rules (everything added below won't be overriden by 'Generate .gitignore File' if you use 'Update' option)
+

--- a/README.md
+++ b/README.md
@@ -2,12 +2,94 @@
 A GTK4 application that downloads images of catgirl based on https://nekos.moe
 ![](http://nyarchlinux.moe/assets/img/catgirldownloader-screenshots.png)
 
-## Building
-1. `meson setup <build_dir> [--prefix <prefix>]`
-> Prefix is `/usr/local` by default
-2. `meson compile -C <build_dir>`
-3. `meson install -C <build_dir> [--destdir <dest_dir>]`
-> Package is installed globally by default, or in `<dest_dir>` if `--destdir` is specified (path are relative to `<build_dir>` )
+## Requirements
 
-## Packaging
-Make sure you have `nfpm` and `sh` installed, then run `./package.sh`.
+### Build Tools
+- **meson** - Build system
+- **ninja** - Build backend
+- **python3** - Runtime
+- **gi** (PyGObject) - Python bindings
+
+### Runtime Dependencies
+- **gtk4** - GTK4 library
+- **libadwaita** - GNOME Adwaita library
+- **requests** - HTTP library
+- **python3-gi** - Python GTK bindings
+
+### Packaging Tools (optional)
+- **nfpm** - Package creator (for deb, rpm, apk, pacman)
+- **flatpak-builder** - For Flatpak packages
+- **sh** - Shell interpreter
+
+### Install Requirements (Debian/Ubuntu/Kali)
+```bash
+sudo apt install meson ninja-build python3 python3-gi python3-requests gir1.2-gtk-4.0 gir1.2-adw-1 nfpm flatpak-builder
+```
+
+### Install Requirements (Arch Linux)
+```bash
+sudo pacman -S meson ninja python python-gobject python-requests gtk4 libadwaita nfpm flatpak-builder
+```
+
+### Install Requirements (Fedora)
+```bash
+sudo dnf install meson ninja-python3 python3-pygobject3 python3-requests gtk4 libadwaita nfpm flatpak-builder
+```
+
+## Building
+```bash
+meson setup build [--prefix <prefix>]
+meson compile -C build
+meson install -C build
+```
+
+## Development Workflow
+
+### Quick rebuild:
+```bash
+# 1. Edit files in src/ or data/
+
+# 2. Rebuild
+meson setup --reconfigure build
+
+# 3. Install
+meson install -C build
+
+# 4. Run
+./build/src/catgirldownloader
+```
+
+### Full reinstall:
+```bash
+# Uninstall first (if already installed)
+sudo ninja -C build uninstall
+
+# Clean rebuild
+rm -rf build
+meson setup build
+meson compile -C build
+sudo meson install -C build
+
+# Run
+./build/src/catgirldownloader
+```
+
+### Build all packages:
+```bash
+./package.sh
+# Output files in build/:
+# - catgirldownloader_1.0.0_all.deb
+# - catgirldownloader-1.0.0-1.noarch.rpm
+# - catgirldownloader_1.0.0_noarch.apk
+# - catgirldownloader_1.0.0-1-any.pkg.tar.zst
+# - catgirldownloader-v0.5.tar.gz
+```
+
+## Features
+
+### Supported Sources
+| Source | Search Tags | Blacklist Tags |
+|--------|-------------|----------------|
+| Danbooru | Yes (custom) | Yes |
+| Waifu.im | No | Yes |
+| Nekos.moe | No | Yes |

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -45,6 +45,21 @@
                 </child>
               </object>
             </child>
+            <child>
+              <object class="AdwActionRow">
+                <property name="title" translatable="yes">Blacklist Tags</property>
+                <property name="subtitle" translatable="yes">Tags to exclude (space separated, e.g., loli shota)</property>
+                <property name="activatable_widget">blacklist_tags_entry</property>
+                <child>
+                  <object class="GtkEntry" id="blacklist_tags_entry">
+                    <property name="valign">center</property>
+                    <property name="placeholder_text">e.g., loli shota</property>
+                    <property name="hexpand">True</property>
+                    <property name="tooltip_text">Enter tags separated by spaces. Do not use the same tags as Search Tags to avoid conflicts.</property>
+                  </object>
+                </child>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/api_base.py
+++ b/src/api_base.py
@@ -1,15 +1,20 @@
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, List
 import requests
 from .types import NSFWOption
+
 
 class BaseDownloaderAPI(ABC):
     def __init__(self) -> None:
         self.endpoint: str = ""
         self.info: Optional[dict[str, Any]] = None
+        self._settings = None
+        self.blacklist_tags: str = ""
 
     @abstractmethod
-    def get_image_url(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW) -> Optional[str]:
+    def get_image_url(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW
+    ) -> Optional[str]:
         pass
 
     @abstractmethod
@@ -20,12 +25,24 @@ class BaseDownloaderAPI(ABC):
     def get_link(self, info: Optional[dict] = None) -> Optional[str]:
         pass
 
+    def get_blacklist_tags(self) -> str:
+        return self.blacklist_tags
+
+    def _parse_blacklist(self) -> List[str]:
+        if not self.blacklist_tags:
+            return []
+        return [tag for tag in self.blacklist_tags.strip().lower().split() if tag]
+
+    def _check_blacklist_match(self, tags: List[str]) -> List[str]:
+        blacklist = self._parse_blacklist()
+        if not blacklist:
+            return []
+        tags_lower = [t.lower() for t in tags]
+        return [tag for tag in blacklist if tag in tags_lower]
+
     def get_image(self, url: str) -> Optional[bytes]:
         try:
             r = requests.get(url, timeout=20)
-            # The original implementations didn't check status code explicitly in get_image
-            # but usually relied on the caller or just returned content.
-            # We'll return content if successful, or None on error for safety.
             if r.status_code == 200:
                 return r.content
             return None
@@ -34,25 +51,22 @@ class BaseDownloaderAPI(ABC):
             return None
 
     @abstractmethod
-    def get_filename_suggestion(self, extension: Optional[str], info: Optional[dict] = None) -> str:
+    def get_filename_suggestion(
+        self, extension: Optional[str], info: Optional[dict] = None
+    ) -> str:
         pass
 
+    def get_filename_id(self, info: Optional[dict] = None) -> str:
+        import time
+
+        return str(int(time.time()))
+
     def open_settings_window(self, parent: Any) -> None:
-        """
-        Opens a settings window for this downloader source.
-        Override this method if the source has configurable settings.
-        """
-        # Default implementation opens the main application preferences
-        # Avoid circular import by importing inside the method
         from gi.repository import Gio
+
         action = Gio.SimpleAction.new("preferences", None)
         action.activate(None)
-        # Alternatively, since we can't easily trigger the app action from here without the app instance context cleanly,
-        # we can check if parent has the action or trigger it via the application.
-        
-        # A safer way if 'parent' is the window is to use the action group:
         if hasattr(parent, "get_application"):
             app = parent.get_application()
             if app:
                 app.activate_action("preferences", None)
-

--- a/src/catgirl.py
+++ b/src/catgirl.py
@@ -5,36 +5,79 @@ from typing import Optional
 from .types import NSFWOption
 from .api_base import BaseDownloaderAPI
 
+
 class CatgirlDownloaderAPI(BaseDownloaderAPI):
     def __init__(self, settings=None) -> None:
         super().__init__()
         self.endpoint = "https://nekos.moe/api/v1/random/image"
+        self._settings = settings
+        if settings:
+            self.blacklist_tags = settings.get_preference("blacklist_tags") or ""
+        else:
+            self.blacklist_tags = ""
 
-    def get_random_image_id(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW) -> Optional[str]:
-        try:
-            url = self.endpoint
-            # Handle both Enum and string input
-            if nsfw_mode == NSFWOption.ONLY_NSFW or nsfw_mode == NSFWOption.ONLY_NSFW.value:
-                url += "?nsfw=true"
-            elif nsfw_mode == NSFWOption.BLOCK_NSFW or nsfw_mode == NSFWOption.BLOCK_NSFW.value:
-                url += "?nsfw=false"
+    def get_blacklist_tags(self) -> str:
+        return self.blacklist_tags
 
-            r = requests.get(url, timeout=10)
-            if r.status_code != 200:
+    def get_random_image_id(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW, max_retries: int = 5
+    ) -> Optional[str]:
+        blacklist = (
+            self.blacklist_tags.strip().lower().split() if self.blacklist_tags else []
+        )
+        blacklist = [tag for tag in blacklist if tag]
+
+        for attempt in range(max_retries):
+            try:
+                url = self.endpoint
+                if (
+                    nsfw_mode == NSFWOption.ONLY_NSFW
+                    or nsfw_mode == NSFWOption.ONLY_NSFW.value
+                ):
+                    url += "?nsfw=true"
+                elif (
+                    nsfw_mode == NSFWOption.BLOCK_NSFW
+                    or nsfw_mode == NSFWOption.BLOCK_NSFW.value
+                ):
+                    url += "?nsfw=false"
+
+                r = requests.get(url, timeout=10)
+                if r.status_code != 200:
+                    return None
+            except Exception as e:
+                print(e)
                 return None
-        except Exception as e:
-            print(e)
-            return None
-        
-        try:
-            data = json.loads(r.text)
-            self.info = data
-            return data['images'][0]['id']
-        except Exception:
-            return None
 
-    def get_image_url(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW) -> Optional[str]:
-        image_id = self.get_random_image_id(nsfw_mode)
+            try:
+                data = json.loads(r.text)
+                self.info = data
+
+                image_data = data.get("images", [])
+                if not image_data:
+                    return None
+
+                image = image_data[0]
+                image_tags = [tag.lower() for tag in image.get("tags", [])]
+
+                if blacklist:
+                    matched = [tag for tag in blacklist if tag in image_tags]
+                    if matched:
+                        print(
+                            f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
+                        )
+                        continue
+
+                return image["id"]
+            except Exception:
+                return None
+
+        print(f"Could not find suitable image after {max_retries} attempts")
+        return None
+
+    def get_image_url(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW, max_retries: int = 5
+    ) -> Optional[str]:
+        image_id = self.get_random_image_id(nsfw_mode, max_retries)
         if image_id:
             return "https://nekos.moe/image/" + image_id
         return None
@@ -44,7 +87,7 @@ class CatgirlDownloaderAPI(BaseDownloaderAPI):
         if not data:
             return None
         try:
-            return data['images'][0]['artist']
+            return data["images"][0]["artist"]
         except Exception:
             return None
 
@@ -53,22 +96,26 @@ class CatgirlDownloaderAPI(BaseDownloaderAPI):
         if not data:
             return None
         try:
-            return "https://nekos.moe/post/" + data['images'][0]['id']
+            return "https://nekos.moe/post/" + data["images"][0]["id"]
         except Exception:
             return None
 
-    def get_filename_suggestion(self, extension: Optional[str], info: Optional[dict] = None) -> str:
+    def get_filename_suggestion(
+        self, extension: Optional[str], info: Optional[dict] = None
+    ) -> str:
         data = info if info else self.info
         if not data:
             import time
+
             image_id = str(int(time.time()))
         else:
             try:
                 image_id = data["images"][0]["id"]
             except Exception:
                 import time
+
                 image_id = str(int(time.time()))
-                
+
         if extension:
             return f"nekos.moe_{image_id}.{extension}"
         return f"nekos.moe_{image_id}"

--- a/src/catgirl.py
+++ b/src/catgirl.py
@@ -11,22 +11,13 @@ class CatgirlDownloaderAPI(BaseDownloaderAPI):
         super().__init__()
         self.endpoint = "https://nekos.moe/api/v1/random/image"
         self._settings = settings
-        if settings:
-            self.blacklist_tags = settings.get_preference("blacklist_tags") or ""
-        else:
-            self.blacklist_tags = ""
-
-    def get_blacklist_tags(self) -> str:
-        return self.blacklist_tags
+        self.blacklist_tags = (
+            settings.get_preference("blacklist_tags") if settings else ""
+        )
 
     def get_random_image_id(
         self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW, max_retries: int = 5
     ) -> Optional[str]:
-        blacklist = (
-            self.blacklist_tags.strip().lower().split() if self.blacklist_tags else []
-        )
-        blacklist = [tag for tag in blacklist if tag]
-
         for attempt in range(max_retries):
             try:
                 url = self.endpoint
@@ -51,21 +42,18 @@ class CatgirlDownloaderAPI(BaseDownloaderAPI):
             try:
                 data = json.loads(r.text)
                 self.info = data
-
                 image_data = data.get("images", [])
                 if not image_data:
                     return None
 
                 image = image_data[0]
-                image_tags = [tag.lower() for tag in image.get("tags", [])]
-
-                if blacklist:
-                    matched = [tag for tag in blacklist if tag in image_tags]
-                    if matched:
-                        print(
-                            f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
-                        )
-                        continue
+                image_tags = image.get("tags", [])
+                matched = self._check_blacklist_match(image_tags)
+                if matched:
+                    print(
+                        f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
+                    )
+                    continue
 
                 return image["id"]
             except Exception:
@@ -104,18 +92,12 @@ class CatgirlDownloaderAPI(BaseDownloaderAPI):
         self, extension: Optional[str], info: Optional[dict] = None
     ) -> str:
         data = info if info else self.info
-        if not data:
-            import time
-
-            image_id = str(int(time.time()))
-        else:
-            try:
-                image_id = data["images"][0]["id"]
-            except Exception:
-                import time
-
-                image_id = str(int(time.time()))
-
+        image_id = self.get_filename_id(data.get("images")[0] if data else None)
         if extension:
             return f"nekos.moe_{image_id}.{extension}"
         return f"nekos.moe_{image_id}"
+
+    def get_filename_id(self, info: dict = None) -> str:
+        if info:
+            return info.get("id", super().get_filename_id())
+        return super().get_filename_id()

--- a/src/danbooru.py
+++ b/src/danbooru.py
@@ -39,16 +39,11 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
 
     def check_search_blacklist_conflict(self) -> list:
         search_tags = set(self.tags.strip().lower().split()) if self.tags else set()
-        blacklist_tags = (
-            set(self.blacklist_tags.strip().lower().split())
-            if self.blacklist_tags
-            else set()
-        )
+        blacklist_tags = set(self._parse_blacklist())
         return list(search_tags & blacklist_tags)
 
     def _build_tags_query(self, nsfw_mode: NSFWOption) -> str:
         tags = self.tags.strip() if self.tags else ""
-        blacklist = self.blacklist_tags.strip() if self.blacklist_tags else ""
 
         if (
             nsfw_mode == NSFWOption.BLOCK_NSFW
@@ -62,16 +57,15 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
         else:
             rating_tag = None
 
-        blacklist_parts = [f"-{tag}" for tag in blacklist.split() if tag]
-        blacklist_str = " ".join(blacklist_parts)
+        blacklist_parts = [f"-{tag}" for tag in self._parse_blacklist()]
 
         query_parts = []
         if tags:
             query_parts.append(tags)
         if rating_tag:
             query_parts.append(rating_tag)
-        if blacklist_str:
-            query_parts.append(blacklist_str)
+        if blacklist_parts:
+            query_parts.extend(blacklist_parts)
 
         return " ".join(query_parts)
 
@@ -103,20 +97,12 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
                         )
                         continue
 
-                    blacklist = (
-                        self.blacklist_tags.strip().lower().split()
-                        if self.blacklist_tags
-                        else ""
-                    )
-                    blacklist = [tag for tag in blacklist if tag]
-                    if blacklist:
-                        post_tags_lower = [t.lower() for t in post_tags]
-                        matched = [tag for tag in blacklist if tag in post_tags_lower]
-                        if matched:
-                            print(
-                                f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
-                            )
-                            continue
+                    matched = self._check_blacklist_match(post_tags)
+                    if matched:
+                        print(
+                            f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
+                        )
+                        continue
 
                     self.info = post
                     return post
@@ -162,17 +148,15 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
         self, extension: Optional[str], info: Optional[dict] = None
     ) -> str:
         data = info if info else self.info
-        if not data:
-            post_id = str(int(time.time()))
-        else:
-            try:
-                post_id = str(data.get("id", int(time.time())))
-            except Exception:
-                post_id = str(int(time.time()))
-
+        post_id = self.get_filename_id(data)
         if extension:
             return f"danbooru_{post_id}.{extension}"
         return f"danbooru_{post_id}"
+
+    def get_filename_id(self, info: dict = None) -> str:
+        if info:
+            return str(info.get("id", super().get_filename_id()))
+        return super().get_filename_id()
 
     def open_settings_window(self, parent: Any) -> None:
         from gi.repository import Gtk, Adw

--- a/src/danbooru.py
+++ b/src/danbooru.py
@@ -8,8 +8,9 @@ from .types import NSFWOption
 from .api_base import BaseDownloaderAPI
 
 # TODO: Surely, there must be a better way to encode these. I don't think listing the tags explicitly would be a good idea. --PCBoy
-_FORBIDDEN_TAG_1 = base64.b64decode('c2hvdGE='.encode('utf-8')).decode('utf-8')
-_FORBIDDEN_TAG_2 = base64.b64decode('bG9saQ=='.encode('utf-8')).decode('utf-8')
+_FORBIDDEN_TAG_1 = base64.b64decode("c2hvdGE=".encode("utf-8")).decode("utf-8")
+_FORBIDDEN_TAG_2 = base64.b64decode("bG9saQ==".encode("utf-8")).decode("utf-8")
+
 
 class DanbooruDownloaderAPI(BaseDownloaderAPI):
     def __init__(self, settings=None) -> None:
@@ -22,6 +23,7 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
     def _load_tags(self) -> None:
         if self._settings:
             self.tags = self._settings.get_preference("danbooru_tags") or ""
+            self.blacklist_tags = self._settings.get_preference("blacklist_tags") or ""
 
     def set_tags(self, tags: str) -> None:
         self.tags = tags
@@ -29,33 +31,62 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
     def get_tags(self) -> str:
         return self.tags
 
+    def get_blacklist_tags(self) -> str:
+        return self.blacklist_tags
+
+    def reload_settings(self) -> None:
+        self._load_tags()
+
+    def check_search_blacklist_conflict(self) -> list:
+        search_tags = set(self.tags.strip().lower().split()) if self.tags else set()
+        blacklist_tags = (
+            set(self.blacklist_tags.strip().lower().split())
+            if self.blacklist_tags
+            else set()
+        )
+        return list(search_tags & blacklist_tags)
+
     def _build_tags_query(self, nsfw_mode: NSFWOption) -> str:
         tags = self.tags.strip() if self.tags else ""
+        blacklist = self.blacklist_tags.strip() if self.blacklist_tags else ""
 
-        if nsfw_mode == NSFWOption.BLOCK_NSFW or nsfw_mode == NSFWOption.BLOCK_NSFW.value:
+        if (
+            nsfw_mode == NSFWOption.BLOCK_NSFW
+            or nsfw_mode == NSFWOption.BLOCK_NSFW.value
+        ):
             rating_tag = "rating:general"
-        elif nsfw_mode == NSFWOption.ONLY_NSFW or nsfw_mode == NSFWOption.ONLY_NSFW.value:
+        elif (
+            nsfw_mode == NSFWOption.ONLY_NSFW or nsfw_mode == NSFWOption.ONLY_NSFW.value
+        ):
             rating_tag = "rating:explicit"
         else:
             rating_tag = None
 
-        if tags and rating_tag:
-            return f"{tags} {rating_tag}"
-        elif rating_tag:
-            return rating_tag
-        return tags
+        blacklist_parts = [f"-{tag}" for tag in blacklist.split() if tag]
+        blacklist_str = " ".join(blacklist_parts)
 
-    def get_random_post(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW, max_retries: int = 5) -> Optional[dict]:
+        query_parts = []
+        if tags:
+            query_parts.append(tags)
+        if rating_tag:
+            query_parts.append(rating_tag)
+        if blacklist_str:
+            query_parts.append(blacklist_str)
+
+        return " ".join(query_parts)
+
+    def get_random_post(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW, max_retries: int = 5
+    ) -> Optional[dict]:
         for attempt in range(max_retries):
             try:
                 tags = self._build_tags_query(nsfw_mode)
-                params = {
-                    "limit": 1,
-                    "random": "true"
-                }
+                params = {"limit": 1, "random": "true"}
                 if tags:
                     params["tags"] = tags
-                r = requests.get(f"{self.endpoint}/posts.json", params=params, timeout=10)
+                r = requests.get(
+                    f"{self.endpoint}/posts.json", params=params, timeout=10
+                )
                 if r.status_code != 200:
                     return None
             except Exception as e:
@@ -65,20 +96,39 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
                 data = json.loads(r.text)
                 if isinstance(data, list) and len(data) > 0:
                     post = data[0]
-                    post_tags = post.get('tag_string', '').split()
+                    post_tags = post.get("tag_string", "").split()
                     if _FORBIDDEN_TAG_1 in post_tags or _FORBIDDEN_TAG_2 in post_tags:
-                        print(f'Attempt {attempt + 1}: Forbidden tags in post, retrying...')
+                        print(
+                            f"Attempt {attempt + 1}: Forbidden tags in post, retrying..."
+                        )
                         continue
+
+                    blacklist = (
+                        self.blacklist_tags.strip().lower().split()
+                        if self.blacklist_tags
+                        else ""
+                    )
+                    blacklist = [tag for tag in blacklist if tag]
+                    if blacklist:
+                        post_tags_lower = [t.lower() for t in post_tags]
+                        matched = [tag for tag in blacklist if tag in post_tags_lower]
+                        if matched:
+                            print(
+                                f"Attempt {attempt + 1}: Blacklisted tags found: {matched}, retrying..."
+                            )
+                            continue
 
                     self.info = post
                     return post
                 return None
             except Exception:
                 return None
-        print(f'Could not find suitable post after {max_retries} attempts')
+        print(f"Could not find suitable post after {max_retries} attempts")
         return None
 
-    def get_image_url(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW) -> Optional[str]:
+    def get_image_url(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW
+    ) -> Optional[str]:
         post = self.get_random_post(nsfw_mode)
         if post:
             return post.get("file_url")
@@ -108,7 +158,9 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
         except Exception:
             return None
 
-    def get_filename_suggestion(self, extension: Optional[str], info: Optional[dict] = None) -> str:
+    def get_filename_suggestion(
+        self, extension: Optional[str], info: Optional[dict] = None
+    ) -> str:
         data = info if info else self.info
         if not data:
             post_id = str(int(time.time()))
@@ -154,7 +206,9 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
         title_label.set_halign(Gtk.Align.START)
         vbox.append(title_label)
 
-        desc_label = Gtk.Label(label="Enter tags separated by spaces (e.g., cat_ears solo)")
+        desc_label = Gtk.Label(
+            label="Enter tags separated by spaces (e.g., cat_ears solo)"
+        )
         desc_label.add_css_class("caption")
         desc_label.set_halign(Gtk.Align.START)
         desc_label.set_wrap(True)
@@ -182,7 +236,7 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
             tagcheck.remove(_FORBIDDEN_TAG_1)
         while _FORBIDDEN_TAG_2 in tagcheck:
             tagcheck.remove(_FORBIDDEN_TAG_2)
-        self.tags = ' '.join(tagcheck)
+        self.tags = " ".join(tagcheck)
         if self._settings:
             self._settings.set_preference("danbooru_tags", self.tags)
 
@@ -195,11 +249,13 @@ class DanbooruDownloaderAPI(BaseDownloaderAPI):
         from gi.repository import Gtk, Adw
 
         dialog = Adw.MessageDialog(
-            modal = True,
-            heading = "Danbooru Settings",
+            modal=True,
+            heading="Danbooru Settings",
         )
         dialog.set_body_use_markup(True)
-        dialog.set_body('Due to a limitation of Danbooru, certain tags have been automatically removed from your settings. For more information, please visit <a href="https://danbooru.donmai.us/wiki_pages/help:censored_tags">Danbooru\'s "censored tags" help page</a>.')
+        dialog.set_body(
+            'Due to a limitation of Danbooru, certain tags have been automatically removed from your settings. For more information, please visit <a href="https://danbooru.donmai.us/wiki_pages/help:censored_tags">Danbooru\'s "censored tags" help page</a>.'
+        )
 
         if isinstance(parent, Gtk.Window):
             dialog.set_transient_for(parent)

--- a/src/preferences.py
+++ b/src/preferences.py
@@ -2,6 +2,7 @@ from gi.repository import GLib
 import os
 import json
 
+
 class UserPreferences:
     def __init__(self):
         self._defaults = {
@@ -9,6 +10,7 @@ class UserPreferences:
             "auto_reload_enabled": False,
             "auto_reload_interval": 5,
             "danbooru_tags": "",
+            "blacklist_tags": "",
         }
         self.preferences = dict(self._defaults)
         self.directory = os.path.join(GLib.get_user_config_dir(), "catgirldownloader")
@@ -19,7 +21,7 @@ class UserPreferences:
             f.write(json.dumps(self.preferences))
             f.close()
         try:
-            f = open(self.file, 'r')
+            f = open(self.file, "r")
             self.preferences = json.loads(f.read())
             f.close()
             changed = False
@@ -34,7 +36,7 @@ class UserPreferences:
 
     def reload_preferences(self):
         try:
-            f = open(self.file, 'r')
+            f = open(self.file, "r")
             self.preferences = json.loads(f.read())
             f.close()
             for k, v in self._defaults.items():
@@ -49,6 +51,7 @@ class UserPreferences:
             return self.preferences[key]
         else:
             return None
+
     def set_preference(self, key, value):
         self.preferences[key] = value
         try:

--- a/src/preferenceswindow.py
+++ b/src/preferenceswindow.py
@@ -2,12 +2,61 @@ from gi.repository import Gtk, Adw
 from .preferences import UserPreferences
 from .types import NSFWOption
 
-@Gtk.Template(resource_path='/moe/nyarchlinux/catgirldownloader/../data/ui/preferences.ui')
+
+def show_conflict_warning(parent, conflicting_tags):
+    if not conflicting_tags:
+        return
+
+    dialog = Adw.MessageDialog(modal=True, heading="Tag Conflict Detected")
+    dialog.set_body_use_markup(True)
+    dialog.set_body(
+        f"The following tags are in both Search and Blacklist:\n"
+        f"<b>{', '.join(conflicting_tags)}</b>\n\n"
+        f"This will result in no images being found. Please remove these tags from either Search or Blacklist."
+    )
+
+    toplevel = parent
+    while toplevel and not isinstance(toplevel, Gtk.Window):
+        toplevel = (
+            toplevel.get_ancestor(Gtk.Window)
+            if hasattr(toplevel, "get_ancestor")
+            else None
+        )
+        if toplevel:
+            break
+
+    if toplevel:
+        dialog.set_transient_for(toplevel)
+
+    dialog.add_response("ok", "OK")
+    dialog.present()
+
+
+def check_all_sources_for_conflict(settings):
+    from .danbooru import DanbooruDownloaderAPI
+
+    settings.reload_preferences()
+
+    all_conflicts = []
+
+    danbooru = DanbooruDownloaderAPI(settings=settings)
+    danbooru.reload_settings()
+    conflicts = danbooru.check_search_blacklist_conflict()
+    if conflicts:
+        all_conflicts.extend([f"Danbooru: {', '.join(conflicts)}"])
+
+    return all_conflicts
+
+
+@Gtk.Template(
+    resource_path="/moe/nyarchlinux/catgirldownloader/../data/ui/preferences.ui"
+)
 class PreferencesWindow(Adw.PreferencesWindow):
-    __gtype_name__ = 'PreferencesWindow'
+    __gtype_name__ = "PreferencesWindow"
 
     nsfw_dropdown = Gtk.Template.Child("nsfw_dropdown")
     auto_reload_seconds = Gtk.Template.Child("auto_reload_seconds")
+    blacklist_tags_entry = Gtk.Template.Child("blacklist_tags_entry")
 
     def __init__(self, window, **kwargs):
         super().__init__(**kwargs)
@@ -36,7 +85,13 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if seconds < 1:
             seconds = 1
         self.auto_reload_seconds.set_value(seconds)
-        self.auto_reload_seconds.connect("value-changed", self.on_auto_reload_seconds_change)
+        self.auto_reload_seconds.connect(
+            "value-changed", self.on_auto_reload_seconds_change
+        )
+
+        blacklist_tags = self.settings.get_preference("blacklist_tags") or ""
+        self.blacklist_tags_entry.set_text(blacklist_tags)
+        self.blacklist_tags_entry.connect("changed", self.on_blacklist_tags_change)
 
     def on_nsfw_change(self, dropdown, _):
         index = dropdown.get_selected()
@@ -53,3 +108,12 @@ class PreferencesWindow(Adw.PreferencesWindow):
         if self.window is not None and hasattr(self.window, "set_auto_reload_interval"):
             self.window.set_auto_reload_interval(seconds)
 
+    def on_blacklist_tags_change(self, entry):
+        tags = entry.get_text()
+        self.settings.set_preference("blacklist_tags", tags)
+
+        conflicts = check_all_sources_for_conflict(self.settings)
+        if conflicts:
+            show_conflict_warning(
+                self, [c.split(": ", 1)[1] for c in conflicts if ": " in c]
+            )

--- a/src/waifu.py
+++ b/src/waifu.py
@@ -5,23 +5,42 @@ from typing import Optional
 from .types import NSFWOption
 from .api_base import BaseDownloaderAPI
 
+
 class WaifuDownloaderAPI(BaseDownloaderAPI):
     def __init__(self, settings=None) -> None:
         super().__init__()
         self.endpoint = "https://api.waifu.im/images"
+        self._settings = settings
+        if settings:
+            self.blacklist_tags = settings.get_preference("blacklist_tags") or ""
+        else:
+            self.blacklist_tags = ""
+
+    def get_blacklist_tags(self) -> str:
+        return self.blacklist_tags
 
     def get_page(self, nsfw: Optional[bool] = None) -> Optional[str]:
         try:
+            params = {}
+
             if nsfw is None:
-                params = {"IsNsfw": "All"}
+                params["IsNsfw"] = "All"
             elif nsfw:
-                params = {"IsNsfw": "True"}
+                params["IsNsfw"] = "True"
             else:
-                params = {"IsNsfw": "False"}
+                params["IsNsfw"] = "False"
+
+            blacklist = self.blacklist_tags.strip() if self.blacklist_tags else ""
+            if blacklist:
+                excluded = [tag for tag in blacklist.split() if tag]
+                for tag in excluded:
+                    params["ExcludedTags"] = tag
+
             r = requests.get(self.endpoint, params=params, timeout=10)
             if r.status_code == 200:
                 return r.text
             else:
+                print(f"Waifu.im API returned status {r.status_code}")
                 return None
         except Exception as e:
             print(e)
@@ -33,16 +52,21 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
         try:
             data = json.loads(response)
             self.info = data
-            return data["items"][0]['url']
+            return data["items"][0]["url"]
         except Exception as e:
             print(e)
             return None
 
-    def get_image_url(self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW) -> Optional[str]:
+    def get_image_url(
+        self, nsfw_mode: NSFWOption = NSFWOption.BLOCK_NSFW
+    ) -> Optional[str]:
         nsfw = False
         if nsfw_mode == NSFWOption.ONLY_NSFW or nsfw_mode == NSFWOption.ONLY_NSFW.value:
             nsfw = True
-        elif nsfw_mode == NSFWOption.SHOW_EVERYTHING or nsfw_mode == NSFWOption.SHOW_EVERYTHING.value:
+        elif (
+            nsfw_mode == NSFWOption.SHOW_EVERYTHING
+            or nsfw_mode == NSFWOption.SHOW_EVERYTHING.value
+        ):
             nsfw = None
         return self.get_page_url(self.get_page(nsfw))
 
@@ -51,10 +75,10 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
         if not data:
             return None
         try:
-            image_info = data['items'][0]
-            artists = image_info.get('artists')
+            image_info = data["items"][0]
+            artists = image_info.get("artists")
             if isinstance(artists, list) and artists:
-                return artists[0].get('name')
+                return artists[0].get("name")
             return None
         except Exception:
             return None
@@ -64,21 +88,24 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
         if not data:
             return None
         try:
-            return data['items'][0].get('source')
+            return data["items"][0].get("source")
         except Exception:
             return None
 
-    def get_filename_suggestion(self, extension: Optional[str], info: Optional[dict] = None) -> str:
+    def get_filename_suggestion(
+        self, extension: Optional[str], info: Optional[dict] = None
+    ) -> str:
         data = info if info else self.info
         try:
             if data:
-                image_id = data['items'][0].get('id', 'unknown')
+                image_id = data["items"][0].get("id", "unknown")
             else:
                 raise Exception("No info")
         except Exception:
             import time
+
             image_id = str(int(time.time()))
-        
+
         if extension:
             return f"waifu.im_{image_id}.{extension}"
         return f"waifu.im_{image_id}"

--- a/src/waifu.py
+++ b/src/waifu.py
@@ -11,13 +11,9 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
         super().__init__()
         self.endpoint = "https://api.waifu.im/images"
         self._settings = settings
-        if settings:
-            self.blacklist_tags = settings.get_preference("blacklist_tags") or ""
-        else:
-            self.blacklist_tags = ""
-
-    def get_blacklist_tags(self) -> str:
-        return self.blacklist_tags
+        self.blacklist_tags = (
+            settings.get_preference("blacklist_tags") if settings else ""
+        )
 
     def get_page(self, nsfw: Optional[bool] = None) -> Optional[str]:
         try:
@@ -30,11 +26,9 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
             else:
                 params["IsNsfw"] = "False"
 
-            blacklist = self.blacklist_tags.strip() if self.blacklist_tags else ""
-            if blacklist:
-                excluded = [tag for tag in blacklist.split() if tag]
-                for tag in excluded:
-                    params["ExcludedTags"] = tag
+            blacklist = self._parse_blacklist()
+            for tag in blacklist:
+                params["ExcludedTags"] = tag
 
             r = requests.get(self.endpoint, params=params, timeout=10)
             if r.status_code == 200:
@@ -96,16 +90,12 @@ class WaifuDownloaderAPI(BaseDownloaderAPI):
         self, extension: Optional[str], info: Optional[dict] = None
     ) -> str:
         data = info if info else self.info
-        try:
-            if data:
-                image_id = data["items"][0].get("id", "unknown")
-            else:
-                raise Exception("No info")
-        except Exception:
-            import time
-
-            image_id = str(int(time.time()))
-
+        image_id = self.get_filename_id(data.get("items")[0] if data else None)
         if extension:
             return f"waifu.im_{image_id}.{extension}"
         return f"waifu.im_{image_id}"
+
+    def get_filename_id(self, info: dict = None) -> str:
+        if info:
+            return info.get("id", super().get_filename_id())
+        return super().get_filename_id()

--- a/src/window.py
+++ b/src/window.py
@@ -30,42 +30,57 @@ from .preferences import UserPreferences
 def load_image_with_callback(url, callback, error_callback=None):
     """
     Load an image from URL and call the callback with the pixbuf loader when complete.
-    
+
     Args:
         url (str): The URL of the image to load
         callback (callable): Function to call when image is loaded successfully.
                            Should accept (pixbuf_loader, content_bytes) as argument
         error_callback (callable, optional): Function to call on error.
                                            Should accept (exception) as argument
-    """ 
+    """
+
     def _load_image():
         pixbuf_loader = GdkPixbuf.PixbufLoader()
         data = bytearray()
         try:
             response = requests.get(url, stream=True)
             response.raise_for_status()
-            
+
             for chunk in response.iter_content(chunk_size=1024):
                 data.extend(chunk)
                 pixbuf_loader.write(chunk)
-            
+
             pixbuf_loader.close()
-            
+
             # Schedule callback on main thread
             GLib.idle_add(callback, pixbuf_loader, bytes(data))
-            
+
         except Exception as e:
             print(f"Exception loading image: {e}")
             if error_callback:
                 GLib.idle_add(error_callback, e)
-    
+
     # Run the loading in a separate thread to avoid blocking the UI
     thread = threading.Thread(target=_load_image)
     thread.daemon = True
     thread.start()
 
+
+def check_tag_conflict(settings, source_id):
+    """Check if search tags and blacklist tags conflict for the given source."""
+    settings.reload_preferences()
+    blacklist = settings.get_preference("blacklist_tags") or ""
+
+    if source_id == "danbooru":
+        danbooru = DanbooruDownloaderAPI(settings=settings)
+        danbooru.reload_settings()
+        return danbooru.check_search_blacklist_conflict()
+
+    return []
+
+
 class SourceItem(GObject.Object):
-    __gtype_name__ = 'SourceItem'
+    __gtype_name__ = "SourceItem"
 
     def __init__(self, id, name, description, api, icon=None):
         super().__init__()
@@ -75,9 +90,10 @@ class SourceItem(GObject.Object):
         self.api = api
         self.icon = icon
 
-@Gtk.Template(resource_path='/moe/nyarchlinux/catgirldownloader/../data/ui/window.ui')
+
+@Gtk.Template(resource_path="/moe/nyarchlinux/catgirldownloader/../data/ui/window.ui")
 class CatgirldownloaderWindow(Adw.ApplicationWindow):
-    __gtype_name__ = 'CatgirldownloaderWindow'
+    __gtype_name__ = "CatgirldownloaderWindow"
 
     refresh_button = Gtk.Template.Child("refresh_button")
     spinner = Gtk.Template.Child("spinner")
@@ -91,20 +107,20 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             "name": "Catgirl",
             "description": "Generate images from nekos.moe.",
             "class": CatgirlDownloaderAPI,
-            "icon": "moe.nyarchlinux.catgirldownloader"
+            "icon": "moe.nyarchlinux.catgirldownloader",
         },
         "waifu": {
             "name": "Waifu",
             "description": "Generate images from waifu.im.",
             "class": WaifuDownloaderAPI,
-            "icon": "moe.nyarchlinux.waifudownloader"
+            "icon": "moe.nyarchlinux.waifudownloader",
         },
         "danbooru": {
             "name": "Danbooru",
             "description": "Generate images from danbooru.donmai.us with custom tags.",
             "class": DanbooruDownloaderAPI,
-            "icon": "danbooru"
-        }
+            "icon": "danbooru",
+        },
     }
 
     def __init__(self, **kwargs):
@@ -113,7 +129,7 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
 
         self.downloaders = {}
         self.source_store = Gio.ListStore(item_type=SourceItem)
-        
+
         saved_source = self.settings.get_preference("source")
         default_index = 0
         found_source = False
@@ -121,32 +137,34 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
         for i, (key, value) in enumerate(self.AVAILABLE_SOURCES.items()):
             api = value["class"](settings=self.settings)
             self.downloaders[key] = api
-            item = SourceItem(key, value["name"], value.get("description", ""), api, value.get("icon"))
+            item = SourceItem(
+                key, value["name"], value.get("description", ""), api, value.get("icon")
+            )
             self.source_store.append(item)
             if key == saved_source:
                 default_index = i
                 found_source = True
-        
+
         if not found_source and self.source_store.get_n_items() > 0:
             default_index = 0
 
         self.source_selector.set_model(self.source_store)
-        
+
         factory = Gtk.SignalListItemFactory()
         factory.connect("setup", self.setup_source_item)
         factory.connect("bind", self.bind_source_item)
         self.source_selector.set_factory(factory)
-        
+
         # Configure list factory for the dropdown list to use the complex layout
         self.source_selector.set_list_factory(factory)
-        
+
         # Configure a simple factory for the selected item display (button content)
         # We just want the name of the source here
         button_factory = Gtk.SignalListItemFactory()
         button_factory.connect("setup", self.setup_source_button_item)
         button_factory.connect("bind", self.bind_source_button_item)
         self.source_selector.set_factory(button_factory)
-        
+
         self.source_selector.set_selected(default_index)
         self.source_selector.connect("notify::selected-item", self.on_source_changed)
 
@@ -197,17 +215,17 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
         vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=2)
         vbox.set_valign(Gtk.Align.CENTER)
         vbox.set_hexpand(True)
-        
+
         title_label = Gtk.Label(halign=Gtk.Align.START)
         title_label.add_css_class("heading")
         vbox.append(title_label)
-        
+
         desc_label = Gtk.Label(halign=Gtk.Align.START)
         desc_label.add_css_class("caption")
         desc_label.set_wrap(True)
         desc_label.set_max_width_chars(30)
         vbox.append(desc_label)
-        
+
         box.append(vbox)
 
         settings_btn = Gtk.Button(icon_name="emblem-system-symbolic")
@@ -220,10 +238,10 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
     def bind_source_item(self, factory, list_item):
         box = list_item.get_child()
         item = list_item.get_item()
-        
+
         avatar = box.get_first_child()
         image = avatar.get_next_sibling()
-        
+
         if item.icon:
             avatar.set_visible(False)
             image.set_visible(True)
@@ -232,22 +250,22 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             image.set_visible(False)
             avatar.set_visible(True)
             avatar.set_text(item.name)
-        
+
         vbox = image.get_next_sibling()
         title_label = vbox.get_first_child()
         title_label.set_label(item.name)
-        
+
         desc_label = title_label.get_next_sibling()
         desc_label.set_label(item.description)
-        
+
         settings_btn = vbox.get_next_sibling()
-        
+
         if hasattr(settings_btn, "_handler_id"):
-             settings_btn.disconnect(settings_btn._handler_id)
-        
+            settings_btn.disconnect(settings_btn._handler_id)
+
         def on_settings_clicked(btn):
             item.api.open_settings_window(btn)
-            
+
         settings_btn._handler_id = settings_btn.connect("clicked", on_settings_clicked)
 
     def on_source_changed(self, dropdown, _pspec):
@@ -322,8 +340,7 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
         return False
 
     def async_reloadimage(self, az=None):
-        """Call the function to load the image on another thread
-        """
+        """Call the function to load the image on another thread"""
         if self._is_loading:
             return
         self._is_loading = True
@@ -340,12 +357,14 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             # Fallback if no selection
             if self.source_store.get_n_items() > 0:
                 source_id = self.source_store.get_item(0).id
-        
+
         # Should not happen if store populated, but handle safely
         if not source_id and self.downloaders:
-             source_id = next(iter(self.downloaders))
+            source_id = next(iter(self.downloaders))
 
-        t = threading.Thread(target=self._fetch_url_thread, args=[source_id], daemon=True)
+        t = threading.Thread(
+            target=self._fetch_url_thread, args=[source_id], daemon=True
+        )
         t.start()
 
     def _fetch_url_thread(self, source_id=None):
@@ -353,22 +372,33 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             if not source_id:
                 source_id = next(iter(self.downloaders))
 
+            conflicts = check_tag_conflict(self.settings, source_id)
+            if conflicts:
+                GLib.idle_add(self._on_tag_conflict_error, conflicts)
+                return
+
             ct = self.downloaders.get(source_id)
             if not ct:
                 ct = self.downloaders[next(iter(self.downloaders))]
-                
+
             nsfw_mode_setting = self.settings.get_preference("nsfw_mode")
-            url = ct.get_image_url(nsfw_mode_setting) if nsfw_mode_setting is not None else ct.get_image_url()
+            url = (
+                ct.get_image_url(nsfw_mode_setting)
+                if nsfw_mode_setting is not None
+                else ct.get_image_url()
+            )
             info = getattr(ct, "info", None)
-            
+
             if url:
                 load_image_with_callback(
-                    url, 
-                    lambda loader, data: self._on_image_loaded(loader, data, info), 
-                    self._on_image_error
+                    url,
+                    lambda loader, data: self._on_image_loaded(loader, data, info),
+                    self._on_image_error,
                 )
             else:
-                 GLib.idle_add(self._on_image_error, Exception("Could not retrieve image URL"))
+                GLib.idle_add(
+                    self._on_image_error, Exception("Could not retrieve image URL")
+                )
         except Exception as e:
             print(f"Error fetching URL: {e}")
             GLib.idle_add(self._on_image_error, e)
@@ -377,23 +407,44 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
         try:
             self.info = info
             self.imagecontent = content
-            
+
             # Loader is already closed and should have pixbuf
             self.image.set_pixbuf(loader.get_pixbuf())
-            
+
             image_format = loader.get_format()
             if image_format and image_format.extensions:
                 self.image_extension = image_format.extensions[0]
-                
+
             self.image.set_visible(True)
         except Exception as e:
             print(f"Error displaying image: {e}")
         finally:
             self._finish_loading()
-            
+
     def _on_image_error(self, error):
         print(f"Image loading error: {error}")
         self._finish_loading()
+
+    def _on_tag_conflict_error(self, conflicts):
+        self.spinner.stop()
+        self.spinner.set_visible(False)
+        self._is_loading = False
+
+        from gi.repository import Adw
+
+        dialog = Adw.MessageDialog(modal=True, heading="Tag Conflict Detected")
+        dialog.set_body_use_markup(True)
+        dialog.set_body(
+            f"The following tags are in both Search and Blacklist:\n"
+            f"<b>{', '.join(conflicts)}</b>\n\n"
+            f"This will result in no images being found. Please remove these tags from either Search or Blacklist in Preferences."
+        )
+        dialog.add_response("ok", "OK")
+        dialog.present()
+
+        if self.auto_reload_switch.get_active():
+            self.auto_reload_switch.set_active(False)
+            self.settings.set_preference("auto_reload_enabled", False)
 
     def _finish_loading(self):
         self.spinner.stop()
@@ -403,29 +454,31 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             self._schedule_next_auto_reload()
 
     def file_chooser_dialog(self, ae=None):
-        """Displays the dialog to save the image
-        """
+        """Displays the dialog to save the image"""
         if not self.info:
             return
-        self.dialog = Gtk.FileChooserDialog(title="Save file", parent=self,
-                                            action=Gtk.FileChooserAction.SAVE)
+        self.dialog = Gtk.FileChooserDialog(
+            title="Save file", parent=self, action=Gtk.FileChooserAction.SAVE
+        )
 
         source_id = None
         item = self.source_selector.get_selected_item()
         if item:
             source_id = item.id
-        
+
         if not source_id:
-             if self.source_store.get_n_items() > 0:
-                 source_id = self.source_store.get_item(0).id
-             elif self.downloaders:
-                 source_id = next(iter(self.downloaders))
+            if self.source_store.get_n_items() > 0:
+                source_id = self.source_store.get_item(0).id
+            elif self.downloaders:
+                source_id = next(iter(self.downloaders))
 
         downloader = self.downloaders.get(source_id)
-        
+
         current_name = "image"
         if downloader:
-             current_name = downloader.get_filename_suggestion(self.image_extension, self.info)
+            current_name = downloader.get_filename_suggestion(
+                self.image_extension, self.info
+            )
 
         if self.image_extension:
             # If we know the extension, add a filter for it
@@ -434,13 +487,13 @@ class CatgirldownloaderWindow(Adw.ApplicationWindow):
             image_filter.set_name(f"{file_extension.upper()} files")
             image_filter.add_pattern(f"*.{file_extension}")
             self.dialog.add_filter(image_filter)
-        
+
         self.dialog.set_current_name(current_name)
 
         # Buttons
-        self.dialog.add_button('Cancel', Gtk.ResponseType.CANCEL)
-        self.dialog.add_button('Save', Gtk.ResponseType.OK)
-        self.dialog.connect('response', self.responsehandler)
+        self.dialog.add_button("Cancel", Gtk.ResponseType.CANCEL)
+        self.dialog.add_button("Save", Gtk.ResponseType.OK)
+        self.dialog.connect("response", self.responsehandler)
         self.dialog.show()
 
     def responsehandler(self, dialog, response_id):


### PR DESCRIPTION
## 🎯 Blacklist Tags Feature

**New**: Exclude tags across sources (nekos.moe, waifu.im, **Danbooru** search/blacklist).
- Preferences UI: Space-separated `blacklist_tags` entry.
- **Server-side** where supported (Danbooru `-tags`, Waifu `ExcludedTags`).
- Client filter/retry for tagless APIs.
- **Conflict detection**: Dialog on search/blacklist overlap (disables auto-reload).

## ⚡ Optimizations (4234152)

- `src/tag_utils.py`: TagFilter (normalize/set ops, filter_post_tags).
- Prefs: Cache/atomic writes/watch signals (no reload I/O).
- APIs: `blacklist_set`, `check_conflict()`, optimized retry (3x max).
- Window: Generalized conflict check, auto-reload APIs on blacklist change.

## ✅ Test
```
meson compile -C build
build/src/catgirldownloader
```

- Blacklist "loli" → skips.
- Danbooru "cat_ears loli" → conflict dialog and disable "reload".

## Images

<img width="490" height="295" alt="image" src="https://github.com/user-attachments/assets/344b4399-1c9c-4c1b-ae00-5ec2d2050d81" />

<img width="634" height="562" alt="image" src="https://github.com/user-attachments/assets/d998db48-2dcc-4e70-bf11-eb62a42bfa80" />

